### PR TITLE
Fix build for ext-proc example

### DIFF
--- a/examples/poc/ext-proc/cache/cache.go
+++ b/examples/poc/ext-proc/cache/cache.go
@@ -85,7 +85,3 @@ type PodCache struct {
 	PodIPMap map[string]string
 	IpPodMap map[string]string
 }
-
-func SetPodCache(cache *freecache.Cache, pods []string) {
-	cacheKey := fmt.Sprintf("")
-}

--- a/examples/poc/ext-proc/main.go
+++ b/examples/poc/ext-proc/main.go
@@ -95,17 +95,6 @@ func main() {
 		log.Fatalf("failed to listen: %v", err)
 	}
 
-	// creates the in-cluster config
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		panic(err.Error())
-	}
-	// creates the clientset
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		panic(err.Error())
-	}
-
 	s := grpc.NewServer()
 
 	extProcPb.RegisterExternalProcessorServer(s, &handlers.Server{


### PR DESCRIPTION
This fixes the following issues when building the binary:

```
> go build -o /ext-proc
cache/cache.go:90:2: cacheKey declared and not used
./main.go:99:17: undefined: rest
./main.go:104:2: clientset declared and not used
./main.go:104:20: undefined: kubernetes
```