### PR TITLE
Improve the filter to return multiple preferred pods instead of one; also fix metrics update bug

### DIFF
--- a/pkg/ext-proc/backend/provider.go
+++ b/pkg/ext-proc/backend/provider.go
@@ -64,14 +64,14 @@ func (p *Provider) Init(refreshPodsInterval, refreshMetricsInterval time.Duratio
 		return fmt.Errorf("failed to init metrics: %v", err)
 	}
 
-	klog.V(2).Infof("Initialized pods and metrics: %+v", p.AllPodMetrics())
+	klog.Infof("Initialized pods and metrics: %+v", p.AllPodMetrics())
 
 	// periodically refresh pods
 	go func() {
 		for {
 			time.Sleep(refreshPodsInterval)
 			if err := p.refreshPodsOnce(); err != nil {
-				klog.V(1).Infof("Failed to refresh podslist pods: %v", err)
+				klog.V(4).Infof("Failed to refresh podslist pods: %v", err)
 			}
 		}
 	}()
@@ -81,10 +81,20 @@ func (p *Provider) Init(refreshPodsInterval, refreshMetricsInterval time.Duratio
 		for {
 			time.Sleep(refreshMetricsInterval)
 			if err := p.refreshMetricsOnce(); err != nil {
-				klog.V(1).Infof("Failed to refresh metrics: %v", err)
+				klog.V(4).Infof("Failed to refresh metrics: %v", err)
 			}
 		}
 	}()
+
+	// Periodically print out the pods and metrics for DEBUGGING.
+	if klog.V(2).Enabled() {
+		go func() {
+			for {
+				time.Sleep(5 * time.Second)
+				klog.Infof("===DEBUG: Current Pods and metrics: %+v", p.AllPodMetrics())
+			}
+		}()
+	}
 
 	return nil
 }

--- a/pkg/ext-proc/handlers/request.go
+++ b/pkg/ext-proc/handlers/request.go
@@ -15,7 +15,7 @@ import (
 // parameter.
 // Envoy sends the request body to ext proc before sending the request to the backend server.
 func (s *Server) HandleRequestBody(reqCtx *RequestContext, req *extProcPb.ProcessingRequest) (*extProcPb.ProcessingResponse, error) {
-	klog.V(2).Infof("Handling request body")
+	klog.V(3).Infof("Handling request body")
 
 	// Unmarshal request body (must be JSON).
 	v := req.Request.(*extProcPb.ProcessingRequest_RequestBody)
@@ -24,14 +24,14 @@ func (s *Server) HandleRequestBody(reqCtx *RequestContext, req *extProcPb.Proces
 		klog.Errorf("Error unmarshaling request body: %v", err)
 		return nil, fmt.Errorf("error unmarshaling request body: %v", err)
 	}
-	klog.V(2).Infof("Request body: %v", rb)
+	klog.V(3).Infof("Request body: %v", rb)
 
 	// Resolve target models.
 	model, ok := rb["model"].(string)
 	if !ok {
 		return nil, fmt.Errorf("model not found in request")
 	}
-	klog.V(2).Infof("Model requested: %v", model)
+	klog.V(3).Infof("Model requested: %v", model)
 	llmReq := &scheduling.LLMRequest{
 		Model: model,
 		// For now use the model as the target model.
@@ -47,13 +47,13 @@ func (s *Server) HandleRequestBody(reqCtx *RequestContext, req *extProcPb.Proces
 		klog.Errorf("Error marshaling request body: %v", err)
 		return nil, fmt.Errorf("error marshaling request body: %v", err)
 	}
-	klog.V(2).Infof("Updated body: %v", updatedBody)
+	klog.V(3).Infof("Updated body: %v", updatedBody)
 
 	targetPod, err := s.scheduler.Schedule(llmReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find target pod: %v", err)
 	}
-	klog.V(2).Infof("Selected target model %v in target pod: %v\n", llmReq.ResolvedTargetModel, targetPod)
+	klog.V(3).Infof("Selected target model %v in target pod: %v\n", llmReq.ResolvedTargetModel, targetPod)
 
 	reqCtx.Model = llmReq.Model
 	reqCtx.TargetPod = targetPod
@@ -69,7 +69,7 @@ func (s *Server) HandleRequestBody(reqCtx *RequestContext, req *extProcPb.Proces
 	}
 	// Print headers for debugging
 	for _, header := range headers {
-		klog.V(2).Infof("[request_body] Header Key: %s, Header Value: %s\n", header.Header.Key, header.Header.RawValue)
+		klog.V(3).Infof("[request_body] Header Key: %s, Header Value: %s\n", header.Header.Key, header.Header.RawValue)
 	}
 
 	resp := &extProcPb.ProcessingResponse{
@@ -93,10 +93,10 @@ func (s *Server) HandleRequestBody(reqCtx *RequestContext, req *extProcPb.Proces
 }
 
 func HandleRequestHeaders(reqCtx *RequestContext, req *extProcPb.ProcessingRequest) *extProcPb.ProcessingResponse {
-	klog.V(2).Info("--- In RequestHeaders processing ...")
+	klog.V(3).Info("--- In RequestHeaders processing ...")
 	r := req.Request
 	h := r.(*extProcPb.ProcessingRequest_RequestHeaders)
-	klog.V(2).Infof("Headers: %+v\n", h)
+	klog.V(3).Infof("Headers: %+v\n", h)
 
 	resp := &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_RequestHeaders{

--- a/pkg/ext-proc/handlers/response.go
+++ b/pkg/ext-proc/handlers/response.go
@@ -8,9 +8,9 @@ import (
 
 // HandleResponseHeaders processes response headers from the backend model server.
 func (s *Server) HandleResponseHeaders(reqCtx *RequestContext, req *extProcPb.ProcessingRequest) (*extProcPb.ProcessingResponse, error) {
-	klog.V(2).Info("Processing ResponseHeaders")
+	klog.V(3).Info("Processing ResponseHeaders")
 	h := req.Request.(*extProcPb.ProcessingRequest_ResponseHeaders)
-	klog.V(2).Infof("Headers before: %+v\n", h)
+	klog.V(3).Infof("Headers before: %+v\n", h)
 
 	resp := &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_ResponseHeaders{

--- a/pkg/ext-proc/scheduling/filter.go
+++ b/pkg/ext-proc/scheduling/filter.go
@@ -43,16 +43,16 @@ func (f *filter) Name() string {
 
 func (f *filter) Filter(b *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error) {
 	if f == nil {
-		klog.V(2).Infof("Running nil filter, returning all input pods by default")
+		klog.V(3).Infof("Running nil filter, returning all input pods by default")
 		return pods, nil
 	}
-	klog.V(2).Infof("Running filter %q on request %v with %v pods", f.name, b, len(pods))
+	klog.V(3).Infof("Running filter %q on request %v with %v pods", f.name, b, len(pods))
 
 	filtered, err := f.filter(b, pods)
 
 	next := f.nextOnSuccessOrFailure
 	if err == nil {
-		klog.V(2).Infof("onSuccess %v -> %v, filtered: %v", f.name, next.Name(), len(filtered))
+		klog.V(3).Infof("onSuccess %v -> %v, filtered: %v", f.name, next.Name(), len(filtered))
 		if f.nextOnSuccess != nil {
 			next = f.nextOnSuccess
 		}
@@ -60,7 +60,7 @@ func (f *filter) Filter(b *LLMRequest, pods []*backend.PodMetrics) ([]*backend.P
 		return next.Filter(b, filtered)
 	}
 
-	klog.V(2).Infof("onFailure %v -> %v", f.name, next.Name())
+	klog.V(3).Infof("onFailure %v -> %v", f.name, next.Name())
 	if f.nextOnFailure != nil {
 		next = f.nextOnFailure
 	}
@@ -88,32 +88,57 @@ func toFilterFunc(pp podPredicate) filterFunc {
 	}
 }
 
+// leastQueuingFilterFunc finds the max and min queue size of all pods, divides the whole range
+// (max-min) by the number of pods, and finds the pods that fall into the first range.
+// The intuition is that if there are multiple pods that share similar queue size in the low range,
+// we should consider them all instead of the absolute minimum one. This worked better than picking
+// the least one as it gives more choices for the next filter, which on aggregate gave better
+// results.
+// TODO: Compare this strategy with other strategies such as top K.
 func leastQueuingFilterFunc(b *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error) {
 	min := math.MaxInt
+	max := 0
 	filtered := []*backend.PodMetrics{}
+
 	for _, pod := range pods {
-		if pod.WaitingQueueSize < min {
+		if pod.WaitingQueueSize <= min {
 			min = pod.WaitingQueueSize
-			filtered = []*backend.PodMetrics{}
 		}
-		if pod.WaitingQueueSize == min {
+		if pod.WaitingQueueSize >= max {
+			max = pod.WaitingQueueSize
+		}
+	}
+
+	for _, pod := range pods {
+		if pod.WaitingQueueSize >= min && pod.WaitingQueueSize <= min+(max-min)/len(pods) {
 			filtered = append(filtered, pod)
 		}
 	}
 	return filtered, nil
 }
 
+// leastKVCacheFilterFunc finds the max and min KV cache of all pods, divides the whole range
+// (max-min) by the number of pods, and finds the pods that fall into the first range.
+// The intuition is that if there are multiple pods that share similar KV cache in the low range, we
+// should consider them all instead of the absolute minimum one. This worked better than picking the
+// least one as it gives more choices for the next filter, which on aggregate gave better results.
+// TODO: Compare this strategy with other strategies such as top K.
 func leastKVCacheFilterFunc(b *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error) {
-	min := math.MaxInt
+	min := math.MaxFloat64
+	max := math.SmallestNonzeroFloat64
 	filtered := []*backend.PodMetrics{}
-	margin := 5
+
 	for _, pod := range pods {
-		cur := int(pod.KVCacheUsagePercent) / margin
-		if cur < min {
-			min = cur
-			filtered = []*backend.PodMetrics{}
+		if pod.KVCacheUsagePercent <= min {
+			min = pod.KVCacheUsagePercent
 		}
-		if cur == min {
+		if pod.KVCacheUsagePercent >= max {
+			max = pod.KVCacheUsagePercent
+		}
+	}
+
+	for _, pod := range pods {
+		if pod.KVCacheUsagePercent >= min && pod.KVCacheUsagePercent <= min+(max-min)/float64(len(pods)) {
 			filtered = append(filtered, pod)
 		}
 	}

--- a/pkg/ext-proc/scheduling/scheduler.go
+++ b/pkg/ext-proc/scheduling/scheduler.go
@@ -2,6 +2,7 @@
 package scheduling
 
 import (
+	"fmt"
 	"math/rand"
 
 	klog "k8s.io/klog/v2"
@@ -44,10 +45,10 @@ type PodMetricsProvider interface {
 
 // Schedule finds the target pod based on metrics and the requested lora adapter.
 func (s *Scheduler) Schedule(b *LLMRequest) (targetPod *backend.Pod, err error) {
-	klog.V(2).Infof("request: %v; metrics: %+v", b, s.podMetricsProvider.AllPodMetrics())
+	klog.V(3).Infof("request: %v; metrics: %+v", b, s.podMetricsProvider.AllPodMetrics())
 	pods, err := s.filter.Filter(b, s.podMetricsProvider.AllPodMetrics())
 	if err != nil || len(pods) == 0 {
-		klog.Errorf("Failed to apply filter, this should never happen: %v", err)
+		return nil, fmt.Errorf("failed to apply filter, resulted %v pods, this should never happen: %v", len(pods), err)
 	}
 	i := rand.Intn(len(pods))
 	return &pods[i].Pod, nil


### PR DESCRIPTION
The updated also allows picking multiple preferred pods instead of one, which improves efficiency when combining with other filters. If we only return one, it's more likely this pod is not preferred by other filtering criteria.

Also updated log levels:
- Level 1, 2: For non-spammy logs like initialization
- Level 3+: For per request debug logs
- Level 4+: For per loop logs like periodically scrape metrics

I made some silly bugs in the initial implementation which caused some metric not getting updated. I was misled by my previous benchmark results, which had lots of errors in the external load balancer. This time I performed benchmarks within the cluster with no errors, and upgraded the benchmark tooling to https://github.com/GoogleCloudPlatform/ai-on-gke/tree/main/benchmarks/benchmark/tools/profile-generator.

The results show that the gateway constantly outperforms basic k8s service in terms of output token throughput and latency (served 10 adapters in 6 vLLM replicas, with max 4 adapters loaded in GPU)

I will share a more detailed benchmark analysis in a doc.

![image](https://github.com/user-attachments/assets/be698674-6327-4b40-b69e-12bd177993b0)


