### PR TITLE
Do not fail Init if fetch metrics fails. It can recover gracefully.

### DIFF
--- a/pkg/ext-proc/backend/provider.go
+++ b/pkg/ext-proc/backend/provider.go
@@ -59,11 +59,10 @@ func (p *Provider) GetPodMetrics(pod Pod) (*PodMetrics, bool) {
 
 func (p *Provider) Init(refreshPodsInterval, refreshMetricsInterval time.Duration) error {
 	if err := p.refreshPodsOnce(); err != nil {
-		return fmt.Errorf("failed to init pods: %v", err)
+		klog.Errorf("Failed to init pods: %v", err)
 	}
-	err := p.refreshMetricsOnce()
-	if err != nil {
-		return fmt.Errorf("failed to init metrics: %v", err)
+	if err := p.refreshMetricsOnce(); err != nil {
+		klog.Errorf("Failed to init metrics: %v", err)
 	}
 
 	klog.Infof("Initialized pods and metrics: %+v", p.AllPodMetrics())

--- a/pkg/ext-proc/backend/provider_test.go
+++ b/pkg/ext-proc/backend/provider_test.go
@@ -71,11 +71,10 @@ func TestProvider(t *testing.T) {
 			datastore: &K8sDatastore{
 				Pods: populateMap(pod1.Pod, pod2.Pod),
 			},
-			initErr: true,
 			want: []*PodMetrics{
 				pod1,
 				// Failed to fetch pod2 metrics so it remains the default values.
-				&PodMetrics{
+				{
 					Pod: Pod{Name: "pod2"},
 					Metrics: Metrics{
 						WaitingQueueSize:    0,


### PR DESCRIPTION
The current implementation will fail to start if fetching pod or metrics fails. Fetching metrics can fail due to 1) transient error 2) lora metrics are not available if dynamic lora is not enabled on the model server.

The binary can recover for 1) and degrade gracefully in 2). Therefore it's better to not block the process from starting.