### PR TITLE
switch to using upstream vllm with new metric 

### DIFF
--- a/examples/poc/manifests/vllm/vllm-lora-deployment.yaml
+++ b/examples/poc/manifests/vllm/vllm-lora-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: lora
-          image: "ghcr.io/tomatillo-and-multiverse/vllm:demo"
+          image: "public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:ac04a97a9fbc122bb14ff4eb590314d453cdf57c"
           imagePullPolicy: Always
           command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
           args:
@@ -40,7 +40,6 @@ spec:
           - "1"
           - "--port"
           - "8000"
-          - "--disable-log-requests"
           - "--enable-lora"
           - "--max-loras"
           - "4"

--- a/examples/poc/manifests/vllm/vllm-lora-deployment.yaml
+++ b/examples/poc/manifests/vllm/vllm-lora-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: lora
-          image: "public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:ac04a97a9fbc122bb14ff4eb590314d453cdf57c"
+          image: "vllm/vllm-openai:latest"
           imagePullPolicy: Always
           command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
           args:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.36.0
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.61.0
+	github.com/stretchr/testify v1.10.0
 	go.uber.org/multierr v1.11.0
 	google.golang.org/grpc v1.68.0
 	google.golang.org/protobuf v1.35.2
@@ -70,6 +71,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.20.4 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect

--- a/pkg/ext-proc/backend/vllm/metrics_test.go
+++ b/pkg/ext-proc/backend/vllm/metrics_test.go
@@ -1,6 +1,7 @@
 package vllm
 
 import (
+	"fmt"
 	"testing"
 
 	"inference.networking.x-k8s.io/llm-instance-gateway/pkg/ext-proc/backend"
@@ -69,32 +70,17 @@ func TestPromToPodMetrics(t *testing.T) {
 						},
 					},
 				},
-				ActiveLoRAAdaptersMetricName: {
-					Metric: []*dto.Metric{
-						{
-							Label: []*dto.LabelPair{
-								{
-									Name:  proto.String("active_adapters"),
-									Value: proto.String("lora1,lora2"),
-								},
-							},
-							Gauge: &dto.Gauge{
-								Value: proto.Float64(100),
-							},
-						},
-					},
-				},
 				LoraRequestInfoMetricName: {
 					Metric: []*dto.Metric{
 						{
 							Label: []*dto.LabelPair{
 								{
-									Name:  proto.String("running_lora_adapters"),
+									Name:  proto.String(LoraRequestInfoRunningAdaptersMetricName),
 									Value: proto.String("lora3,lora4"),
 								},
 								{
-									Name:  proto.String("waiting_lora_adapters"),
-									Value: proto.String("lora1,lora4"),
+									Name:  proto.String(LoraRequestInfoMaxAdaptersMetricName),
+									Value: proto.String("2"),
 								},
 							},
 							Gauge: &dto.Gauge{
@@ -104,8 +90,12 @@ func TestPromToPodMetrics(t *testing.T) {
 						{
 							Label: []*dto.LabelPair{
 								{
-									Name:  proto.String("running_lora_adapters"),
+									Name:  proto.String(LoraRequestInfoRunningAdaptersMetricName),
 									Value: proto.String("lora2"),
+								},
+								{
+									Name:  proto.String(LoraRequestInfoMaxAdaptersMetricName),
+									Value: proto.String("2"),
 								},
 							},
 							Gauge: &dto.Gauge{
@@ -119,13 +109,113 @@ func TestPromToPodMetrics(t *testing.T) {
 				RunningQueueSize:    15,
 				WaitingQueueSize:    25,
 				KVCacheUsagePercent: 0.9,
-				CachedModels: map[string]int{
+				ActiveModels: map[string]int{
 					"lora3": 0,
 					"lora4": 0,
 				},
+				MaxActiveModels: 2,
 			},
 			initialPodMetrics: &backend.PodMetrics{},
 			expectedErr:       nil,
+		},
+		{
+			name: "invalid max lora",
+			metricFamilies: map[string]*dto.MetricFamily{
+				RunningQueueSizeMetricName: {
+					Metric: []*dto.Metric{
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(10),
+							},
+							TimestampMs: proto.Int64(100),
+						},
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(15),
+							},
+							TimestampMs: proto.Int64(200), // This is the latest
+						},
+					},
+				},
+				WaitingQueueSizeMetricName: {
+					Metric: []*dto.Metric{
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(20),
+							},
+							TimestampMs: proto.Int64(100),
+						},
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(25),
+							},
+							TimestampMs: proto.Int64(200), // This is the latest
+						},
+					},
+				},
+				KVCacheUsagePercentMetricName: {
+					Metric: []*dto.Metric{
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(0.8),
+							},
+							TimestampMs: proto.Int64(100),
+						},
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(0.9),
+							},
+							TimestampMs: proto.Int64(200), // This is the latest
+						},
+					},
+				},
+				LoraRequestInfoMetricName: {
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{
+									Name:  proto.String(LoraRequestInfoRunningAdaptersMetricName),
+									Value: proto.String("lora3,lora4"),
+								},
+								{
+									Name:  proto.String(LoraRequestInfoRunningAdaptersMetricName),
+									Value: proto.String("2a"),
+								},
+							},
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(100),
+							},
+						},
+						{
+							Label: []*dto.LabelPair{
+								{
+									Name:  proto.String(LoraRequestInfoRunningAdaptersMetricName),
+									Value: proto.String("lora2"),
+								},
+								{
+									Name:  proto.String(LoraRequestInfoMaxAdaptersMetricName),
+									Value: proto.String("2"),
+								},
+							},
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(90),
+							},
+						},
+					},
+				},
+			},
+			expectedMetrics: &backend.Metrics{
+				RunningQueueSize:    15,
+				WaitingQueueSize:    25,
+				KVCacheUsagePercent: 0.9,
+				ActiveModels: map[string]int{
+					"lora3": 0,
+					"lora4": 0,
+				},
+				MaxActiveModels: 0,
+			},
+			initialPodMetrics: &backend.PodMetrics{},
+			expectedErr:       fmt.Errorf("strconv.Atoi: parsing '2a': invalid syntax"),
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/ext-proc/backend/vllm/metrics_test.go
+++ b/pkg/ext-proc/backend/vllm/metrics_test.go
@@ -1,0 +1,142 @@
+package vllm
+
+import (
+	"testing"
+
+	"inference.networking.x-k8s.io/llm-instance-gateway/pkg/ext-proc/backend"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestPromToPodMetrics(t *testing.T) {
+	testCases := []struct {
+		name              string
+		metricFamilies    map[string]*dto.MetricFamily
+		expectedMetrics   *backend.Metrics
+		expectedErr       error
+		initialPodMetrics *backend.PodMetrics
+	}{
+		{
+			name: "all metrics available",
+			metricFamilies: map[string]*dto.MetricFamily{
+				RunningQueueSizeMetricName: {
+					Metric: []*dto.Metric{
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(10),
+							},
+							TimestampMs: proto.Int64(100),
+						},
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(15),
+							},
+							TimestampMs: proto.Int64(200), // This is the latest
+						},
+					},
+				},
+				WaitingQueueSizeMetricName: {
+					Metric: []*dto.Metric{
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(20),
+							},
+							TimestampMs: proto.Int64(100),
+						},
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(25),
+							},
+							TimestampMs: proto.Int64(200), // This is the latest
+						},
+					},
+				},
+				KVCacheUsagePercentMetricName: {
+					Metric: []*dto.Metric{
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(0.8),
+							},
+							TimestampMs: proto.Int64(100),
+						},
+						{
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(0.9),
+							},
+							TimestampMs: proto.Int64(200), // This is the latest
+						},
+					},
+				},
+				ActiveLoRAAdaptersMetricName: {
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{
+									Name:  proto.String("active_adapters"),
+									Value: proto.String("lora1,lora2"),
+								},
+							},
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(100),
+							},
+						},
+					},
+				},
+				LoraRequestInfoMetricName: {
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{
+									Name:  proto.String("running_lora_adapters"),
+									Value: proto.String("lora3,lora4"),
+								},
+								{
+									Name:  proto.String("waiting_lora_adapters"),
+									Value: proto.String("lora1,lora4"),
+								},
+							},
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(100),
+							},
+						},
+						{
+							Label: []*dto.LabelPair{
+								{
+									Name:  proto.String("running_lora_adapters"),
+									Value: proto.String("lora2"),
+								},
+							},
+							Gauge: &dto.Gauge{
+								Value: proto.Float64(90),
+							},
+						},
+					},
+				},
+			},
+			expectedMetrics: &backend.Metrics{
+				RunningQueueSize:    15,
+				WaitingQueueSize:    25,
+				KVCacheUsagePercent: 0.9,
+				CachedModels: map[string]int{
+					"lora3": 0,
+					"lora4": 0,
+				},
+			},
+			initialPodMetrics: &backend.PodMetrics{},
+			expectedErr:       nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			updated, err := promToPodMetrics(tc.metricFamilies, tc.initialPodMetrics)
+			if tc.expectedErr != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedMetrics, &updated.Metrics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- switch to using upstream vllm with new metric
- use latest series in gauge metric vllm:lora_requests_info using the time value of the series
- Use label pair running_lora_adapters
- update vllm example deployment to use latest
Fixes #22 