### PR TITLE
Integrating LLMService with weight splitting

### DIFF
--- a/pkg/ext-proc/backend/datastore.go
+++ b/pkg/ext-proc/backend/datastore.go
@@ -1,10 +1,12 @@
 package backend
 
 import (
+	"math/rand"
 	"sync"
 
 	"inference.networking.x-k8s.io/llm-instance-gateway/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 )
 
 // The datastore is a local cache of relevant data for the given LLMServerPool (currently all pulled from k8s-api)
@@ -21,4 +23,34 @@ func (ds *K8sDatastore) GetPodIPs() []string {
 		return true
 	})
 	return ips
+}
+
+func RandomWeightedDraw(model *v1alpha1.Model, seed int64) string {
+	weights := 0
+
+	source := rand.NewSource(rand.Int63())
+	if seed > 0 {
+		source = rand.NewSource(seed)
+	}
+	r := rand.New(source)
+	for _, model := range model.TargetModels {
+		weights += model.Weight
+	}
+	klog.Infof("Weights for Model(%v) total to: %v", model.Name, weights)
+	randomVal := r.Intn(weights)
+	for _, model := range model.TargetModels {
+		if randomVal < model.Weight {
+			return model.Name
+		}
+		randomVal -= model.Weight
+	}
+	return ""
+}
+
+func ModelHasObjective(model *v1alpha1.Model) bool {
+	if model.Objective != nil && model.Objective.DesiredAveragePerOutputTokenLatencyAtP95OverMultipleRequests != nil {
+		return true
+	}
+
+	return false
 }

--- a/pkg/ext-proc/backend/datastore_test.go
+++ b/pkg/ext-proc/backend/datastore_test.go
@@ -1,0 +1,88 @@
+package backend
+
+import (
+	"testing"
+
+	"inference.networking.x-k8s.io/llm-instance-gateway/api/v1alpha1"
+)
+
+var ()
+
+func TestRandomWeightedDraw(t *testing.T) {
+	tests := []struct {
+		name      string
+		datastore K8sDatastore
+		model     *v1alpha1.Model
+		want      string
+	}{
+		{
+			name: "'random' distribution",
+			model: &v1alpha1.Model{
+				TargetModels: []v1alpha1.TargetModel{
+					{
+						Name:   "canary",
+						Weight: 50,
+					},
+					{
+						Name:   "v1",
+						Weight: 50,
+					},
+				},
+			},
+			want: "canary",
+		},
+		{
+			name: "'random' distribution",
+			model: &v1alpha1.Model{
+				TargetModels: []v1alpha1.TargetModel{
+					{
+						Name:   "canary",
+						Weight: 25,
+					},
+					{
+						Name:   "v1.1",
+						Weight: 55,
+					},
+					{
+						Name:   "v1",
+						Weight: 50,
+					},
+				},
+			},
+			want: "v1",
+		},
+		{
+			name: "'random' distribution",
+			model: &v1alpha1.Model{
+				TargetModels: []v1alpha1.TargetModel{
+					{
+						Name:   "canary",
+						Weight: 20,
+					},
+					{
+						Name:   "v1.1",
+						Weight: 20,
+					},
+					{
+						Name:   "v1",
+						Weight: 10,
+					},
+				},
+			},
+			want: "v1.1",
+		},
+	}
+	var seedVal int64
+	seedVal = 420
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for range 10000 {
+				model := RandomWeightedDraw(test.model, seedVal)
+				if model != test.want {
+					t.Errorf("Model returned!: %v", model)
+					break
+				}
+			}
+		})
+	}
+}

--- a/pkg/ext-proc/handlers/server.go
+++ b/pkg/ext-proc/handlers/server.go
@@ -13,11 +13,12 @@ import (
 	"inference.networking.x-k8s.io/llm-instance-gateway/pkg/ext-proc/scheduling"
 )
 
-func NewServer(pp PodProvider, scheduler Scheduler, targetPodHeader string) *Server {
+func NewServer(pp PodProvider, scheduler Scheduler, targetPodHeader string, datastore *backend.K8sDatastore) *Server {
 	return &Server{
 		scheduler:       scheduler,
 		podProvider:     pp,
 		targetPodHeader: targetPodHeader,
+		datastore:       datastore,
 	}
 }
 
@@ -29,6 +30,7 @@ type Server struct {
 	// The key of the header to specify the target pod address. This value needs to match Envoy
 	// configuration.
 	targetPodHeader string
+	datastore       *backend.K8sDatastore
 }
 
 type Scheduler interface {

--- a/pkg/ext-proc/main.go
+++ b/pkg/ext-proc/main.go
@@ -132,7 +132,7 @@ func main() {
 	if err := pp.Init(*refreshPodsInterval, *refreshMetricsInterval); err != nil {
 		klog.Fatalf("failed to initialize: %v", err)
 	}
-	extProcPb.RegisterExternalProcessorServer(s, handlers.NewServer(pp, scheduling.NewScheduler(pp), *targetPodHeader))
+	extProcPb.RegisterExternalProcessorServer(s, handlers.NewServer(pp, scheduling.NewScheduler(pp), *targetPodHeader, datastore))
 	healthPb.RegisterHealthServer(s, &healthServer{})
 
 	klog.Infof("Starting gRPC server on port :%v", *port)


### PR DESCRIPTION
This PR allows LLMService to be used, and weight splitting to be achieves when using the appropriately configured model name.