### PR TITLE
Fix codegen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 echo "$SCRIPT_ROOT script"
-CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
+CODEGEN_PKG=${2:-bin}
 echo $CODEGEN_PKG
 source "${CODEGEN_PKG}/kube_codegen.sh"
 THIS_PKG="inference.networking.x-k8s.io/llm-instance-gateway"


### PR DESCRIPTION
When I ran `make generate`, I ran into error 

```
./hack/.. script
../code-generator
./hack/update-codegen.sh: line 25: ../code-generator/kube_codegen.sh: No such file or directory
```

This fix was from the LWS repo: https://github.com/kubernetes-sigs/lws/blob/ed2b1f9848b6f38dfd553ccd838671933a343be5/hack/update-codegen.sh#L23 